### PR TITLE
Fix relative include path and remove closing tags

### DIFF
--- a/include/bootstrap.php
+++ b/include/bootstrap.php
@@ -1,5 +1,5 @@
 <?php
 
-	if (!defined("__WEIRDOS__")) { die(); }
-
-?>
+        if (!defined('__WEIRDOS__')) {
+            die();
+        }

--- a/index.php
+++ b/index.php
@@ -2,8 +2,6 @@
 
 	define('__WEIRDOS__', 'weirdos'); // Main entry point lock
 	
-	require_once 'include/bootstrap.php';
+        require_once __DIR__ . '/include/bootstrap.php';
 	
-	echo "Hello to 2015!";
-
-?>
+        echo "Hello to 2015!";


### PR DESCRIPTION
## Summary
- update index.php to require `bootstrap.php` using an absolute path
- drop PHP closing tags and add newlines at EOF
- tidy the bootstrap sanity check

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684186e35cec83329f40a2b99240200d